### PR TITLE
fix: background image not rendering in compositor

### DIFF
--- a/automation/hybrid-image-generator/layouts/base-styles.css
+++ b/automation/hybrid-image-generator/layouts/base-styles.css
@@ -22,7 +22,7 @@ body {
   height: 100%;
   z-index: 0;
   background-color: var(--bg-color, var(--bg-primary, #f8f8f8));
-  background-image: url('{{backgroundUrl}}');
+  background-image: url('{{{backgroundUrl}}}');
   background-size: cover;
   background-position: center;
   background-repeat: no-repeat;


### PR DESCRIPTION
## Summary

- Fix Mustache HTML-escaping bug that prevented AI-generated backgrounds from rendering in the Puppeteer compositor
- `{{backgroundUrl}}` was escaping `/` to `&#x2F;` in `data:image/png` data URLs, breaking the CSS `background-image` property
- Changed to `{{{backgroundUrl}}}` (triple-mustache, unescaped) in `base-styles.css`

## Root Cause

This was a **pre-existing bug** — AI-generated whiteboard backgrounds from Gemini/DALL-E have never actually composited in the final PNG output. The content rendered correctly but always used the CSS fallback color instead of the photorealistic background.

## Verification

Tested E2E with Gemini Flash across all 4 themes × 4 layouts:
- Before fix: ~125KB output (CSS fallback only)
- After fix: ~1.5-3MB output (real photorealistic whiteboard background composited)

## Test plan

- [x] `node -r dotenv/config hybrid-image-generator/scripts/generate-samples.js --pillar` — 6/6 pass with real Gemini backgrounds
- [x] `node hybrid-image-generator/tests/test-main-api.js` — 5/5 pass (IMAGE_PROVIDER=none)
- [x] `node hybrid-image-generator/tests/test-themes.js` — 11/11 pass
- [x] Visual verification of all generated PNGs

🤖 Generated with [Claude Code](https://claude.com/claude-code)